### PR TITLE
Feature/spatial restriction geometrytype

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,9 +97,9 @@ subprojects { subProject ->
 
     defaultTasks 'build'
 
-	if ( subProject.name.startsWith( 'hibernate-gradle-plugin' ) ) {
-		apply plugin: 'groovy'
-	}
+    if ( subProject.name.startsWith( 'hibernate-gradle-plugin' ) ) {
+        apply plugin: 'groovy'
+    }
 
     group = 'org.hibernate'
     version = rootProject.hibernateTargetVersion

--- a/hibernate-core/src/main/java/org/hibernate/engine/query/spi/NativeSQLQueryPlan.java
+++ b/hibernate-core/src/main/java/org/hibernate/engine/query/spi/NativeSQLQueryPlan.java
@@ -17,6 +17,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.QueryException;
 import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.engine.spi.QueryParameters;
+import org.hibernate.engine.spi.RowSelection;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.engine.spi.TypedValue;
 import org.hibernate.event.spi.EventSource;
@@ -181,6 +182,7 @@ public class NativeSQLQueryPlan implements Serializable {
 
 		int result = 0;
 		PreparedStatement ps;
+		RowSelection selection = queryParameters.getRowSelection();
 		try {
 			queryParameters.processFilters( this.customQuery.getSQL(), session );
 			final String sql = session.getJdbcServices().getDialect()
@@ -196,6 +198,9 @@ public class NativeSQLQueryPlan implements Serializable {
 				int col = 1;
 				col += bindPositionalParameters( ps, queryParameters, col, session );
 				col += bindNamedParameters( ps, queryParameters.getNamedParameters(), col, session );
+				if ( selection != null && selection.getTimeout() != null ) {
+					ps.setQueryTimeout( selection.getTimeout() );
+				}
 				result = session.getJdbcCoordinator().getResultSetReturn().executeUpdate( ps );
 			}
 			finally {

--- a/hibernate-core/src/test/java/org/hibernate/test/querytimeout/QueryTimeOutTest.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/querytimeout/QueryTimeOutTest.java
@@ -1,0 +1,178 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.querytimeout;
+
+import java.sql.SQLException;
+import java.util.Map;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.QueryHint;
+import javax.persistence.Table;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.jpa.QueryHints;
+import org.hibernate.query.NativeQuery;
+import org.hibernate.query.Query;
+
+import org.hibernate.testing.TestForIssue;
+import org.hibernate.testing.junit4.BaseNonConfigCoreFunctionalTestCase;
+import org.hibernate.test.util.jdbc.PreparedStatementSpyConnectionProvider;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hibernate.testing.transaction.TransactionUtil.doInHibernate;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Gail Badner
+ */
+public class QueryTimeOutTest extends BaseNonConfigCoreFunctionalTestCase {
+
+	private static final PreparedStatementSpyConnectionProvider CONNECTION_PROVIDER = new PreparedStatementSpyConnectionProvider();
+	private static final String QUERY = "update AnEntity set name='abc'";
+
+	@Override
+	protected Class[] getAnnotatedClasses() {
+		return new Class[] { AnEntity.class };
+	}
+
+	@Override
+	protected void addSettings(Map settings) {
+		settings.put( AvailableSettings.CONNECTION_PROVIDER, CONNECTION_PROVIDER );
+	}
+
+	@Before
+	public void before() {
+		CONNECTION_PROVIDER.clear();
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-12075")
+	public void testCreateQuerySetTimeout() {
+		doInHibernate(
+				this::sessionFactory, session -> {
+					Query query = session.createQuery( QUERY );
+					query.setTimeout( 123 );
+					query.executeUpdate();
+
+					try {
+						verify( CONNECTION_PROVIDER.getPreparedStatement( QUERY ), times( 1 ) ).setQueryTimeout( 123 );
+					}
+					catch (SQLException ex) {
+						fail( "should not have thrown exception" );
+					}
+				}
+		);
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-12075")
+	public void testCreateQuerySetTimeoutHint() {
+		doInHibernate(
+				this::sessionFactory, session -> {
+					Query query = session.createQuery( QUERY );
+					query.setHint( QueryHints.SPEC_HINT_TIMEOUT, 123000 );
+					query.executeUpdate();
+
+					try {
+						verify( CONNECTION_PROVIDER.getPreparedStatement( QUERY ), times( 1 ) ).setQueryTimeout( 123 );
+					}
+					catch (SQLException ex) {
+						fail( "should not have thrown exception" );
+					}
+				}
+		);
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-12075")
+	public void testCreateNativeQuerySetTimeout() {
+		doInHibernate(
+				this::sessionFactory, session -> {
+					NativeQuery query = session.createNativeQuery( QUERY );
+					query.setTimeout( 123 );
+					query.executeUpdate();
+
+					try {
+						verify( CONNECTION_PROVIDER.getPreparedStatement( QUERY ), times( 1 ) ).setQueryTimeout( 123 );
+					}
+					catch (SQLException ex) {
+						fail( "should not have thrown exception" );
+					}
+				}
+		);
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-12075")
+	public void testCreateNativeQuerySetTimeoutHint() {
+		doInHibernate(
+				this::sessionFactory, session -> {
+					NativeQuery query = session.createNativeQuery( QUERY );
+					query.setHint( QueryHints.SPEC_HINT_TIMEOUT, 123000 );
+					query.executeUpdate();
+
+					try {
+						verify( CONNECTION_PROVIDER.getPreparedStatement( QUERY ), times( 1 ) ).setQueryTimeout( 123 );
+					}
+					catch (SQLException ex) {
+						fail( "should not have thrown exception" );
+					}
+				}
+		);
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-12075")
+	public void testCreateSQLQuerySetTimeout() {
+		doInHibernate(
+				this::sessionFactory, session -> {
+					NativeQuery query = session.createSQLQuery( QUERY );
+					query.setTimeout( 123 );
+					query.executeUpdate();
+
+					try {
+						verify( CONNECTION_PROVIDER.getPreparedStatement( QUERY ), times( 1 ) ).setQueryTimeout( 123 );
+					}
+					catch (SQLException ex) {
+						fail( "should not have thrown exception" );
+					}
+				}
+		);
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HHH-12075")
+	public void testCreateSQLQuerySetTimeoutHint() {
+		doInHibernate(
+				this::sessionFactory, session -> {
+					NativeQuery query = session.createSQLQuery( QUERY );
+					query.setHint( QueryHints.SPEC_HINT_TIMEOUT, 123000 );
+					query.executeUpdate();
+
+					try {
+						verify( CONNECTION_PROVIDER.getPreparedStatement( QUERY ), times( 1 ) ).setQueryTimeout( 123 );
+					}
+					catch (SQLException ex) {
+						fail( "should not have thrown exception" );
+					}
+				}
+		);
+	}
+
+	@Entity(name = "AnEntity" )
+	@Table(name = "AnEntity" )
+	public static class AnEntity {
+		@Id
+		private int id;
+
+		private String name;
+	}
+}

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/impl/BaseTransactionalDataRegion.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/impl/BaseTransactionalDataRegion.java
@@ -17,11 +17,7 @@ import org.hibernate.cache.infinispan.access.TombstoneCallInterceptor;
 import org.hibernate.cache.infinispan.access.TxInvalidationCacheAccessDelegate;
 import org.hibernate.cache.infinispan.access.UnorderedDistributionInterceptor;
 import org.hibernate.cache.infinispan.access.VersionedCallInterceptor;
-import org.hibernate.cache.infinispan.util.Caches;
-import org.hibernate.cache.infinispan.util.FutureUpdate;
-import org.hibernate.cache.infinispan.util.InfinispanMessageLogger;
-import org.hibernate.cache.infinispan.util.Tombstone;
-import org.hibernate.cache.infinispan.util.VersionedEntry;
+import org.hibernate.cache.infinispan.util.*;
 import org.hibernate.cache.spi.CacheDataDescription;
 import org.hibernate.cache.spi.CacheKeysFactory;
 import org.hibernate.cache.spi.TransactionalDataRegion;
@@ -148,8 +144,16 @@ public abstract class BaseTransactionalDataRegion
 			assert strategy == Strategy.VALIDATION;
 			return;
 		}
-		validator = new PutFromLoadValidator(cache, factory);
-		strategy = Strategy.VALIDATION;
+		synchronized (this) {
+			PutFromLoadValidator found = findValidator(cache);
+			validator = found != null ? found : new PutFromLoadValidator(cache, factory);
+			strategy = Strategy.VALIDATION;
+		}
+	}
+
+	private PutFromLoadValidator findValidator(AdvancedCache cache) {
+		CacheCommandInitializer cmdInit = cache.getComponentRegistry().getComponent(CacheCommandInitializer.class);
+		return cmdInit.findPutFromLoadValidator(cache.getName());
 	}
 
 	protected void prepareForVersionedEntries() {

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/impl/BaseTransactionalDataRegion.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/impl/BaseTransactionalDataRegion.java
@@ -144,7 +144,11 @@ public abstract class BaseTransactionalDataRegion
 			assert strategy == Strategy.VALIDATION;
 			return;
 		}
-		synchronized (this) {
+		// If two regions share the same name, they should use the same cache.
+		// Using same cache means they should use the same put validator.
+		// Besides, any cache interceptor initialization should only be done once.
+		// Synchronizes on the cache instance since it's shared between regions with same name.
+		synchronized (cache) {
 			PutFromLoadValidator found = findValidator(cache);
 			validator = found != null ? found : new PutFromLoadValidator(cache, factory);
 			strategy = Strategy.VALIDATION;

--- a/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/util/CacheCommandInitializer.java
+++ b/hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/util/CacheCommandInitializer.java
@@ -48,6 +48,10 @@ public class CacheCommandInitializer implements ModuleCommandInitializer {
 		putFromLoadValidators.put(cacheName, putFromLoadValidator);
 	}
 
+	public PutFromLoadValidator findPutFromLoadValidator(String cacheName) {
+		return putFromLoadValidators.get(cacheName);
+	}
+
 	public PutFromLoadValidator removePutFromLoadValidator(String cacheName) {
 		return putFromLoadValidators.remove(cacheName);
 	}

--- a/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/functional/EntitiesAndCollectionsInSameRegionTest.java
+++ b/hibernate-infinispan/src/test/java/org/hibernate/test/cache/infinispan/functional/EntitiesAndCollectionsInSameRegionTest.java
@@ -1,0 +1,233 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.test.cache.infinispan.functional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.Hibernate;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.cache.internal.DefaultCacheKeysFactory;
+import org.hibernate.cfg.Environment;
+import org.hibernate.stat.SecondLevelCacheStatistics;
+import org.hibernate.stat.Statistics;
+
+import org.hibernate.testing.TestForIssue;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * @author Gail Badner
+ */
+public class EntitiesAndCollectionsInSameRegionTest extends SingleNodeTest {
+	private static final String REGION_NAME = "ARegion";
+
+	private final AnEntity anEntity;
+	private final AnotherEntity anotherEntity;
+
+	public EntitiesAndCollectionsInSameRegionTest() {
+		anEntity = new AnEntity();
+		anEntity.id = 1;
+		anEntity.values.add( "abc" );
+
+		anotherEntity = new AnotherEntity();
+		anotherEntity.id = 1;
+		anotherEntity.values.add( 123 );
+	}
+
+	@Override
+	public List<Object[]> getParameters() {
+		return getParameters( true, false, false, false );
+	}
+
+	@Override
+	public Class[] getAnnotatedClasses() {
+		return new Class[] {
+				AnEntity.class,
+				AnotherEntity.class
+		};
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	protected void addSettings(Map settings) {
+		super.addSettings( settings );
+		settings.put( Environment.CACHE_KEYS_FACTORY, DefaultCacheKeysFactory.SHORT_NAME );
+
+	}
+
+	@Before
+	public void setup() throws Exception {
+
+		final Statistics stats = sessionFactory().getStatistics();
+		stats.clear();
+
+		withTxSession(
+				s -> {
+					s.persist( anEntity );
+					s.persist( anotherEntity );
+				}
+		);
+
+		// Then entities should have been cached, but not their collections.
+		SecondLevelCacheStatistics cacheStatistics = stats.getSecondLevelCacheStatistics( REGION_NAME );
+		assertEquals( 0, cacheStatistics.getMissCount() );
+		assertEquals( 0, cacheStatistics.getHitCount() );
+		assertEquals( 2, cacheStatistics.getPutCount() );
+
+		stats.clear();
+	}
+
+	@After
+	public void cleanup() throws Exception{
+		withTxSession(
+				s -> {
+					s.delete( s.get( AnEntity.class, 1 ) );
+					s.delete( s.get( AnotherEntity.class, 1 ) );
+				}
+		);
+	}
+
+
+	@Test
+	@TestForIssue(jiraKey = "HHH-10418")
+	public void testEntitiesAndCollections() throws Exception {
+
+		final Statistics stats = sessionFactory().getStatistics();
+		stats.clear();
+
+		withTxSession(
+				s -> {
+					AnEntity anEntity1 = s.get( AnEntity.class, anEntity.id );
+
+					SecondLevelCacheStatistics cacheStatistics = stats.getSecondLevelCacheStatistics( REGION_NAME );
+
+					// anEntity1 was cached when it was persisted
+					assertEquals( 0, cacheStatistics.getMissCount() );
+					assertEquals( 1, cacheStatistics.getHitCount() );
+					assertEquals( 0, cacheStatistics.getPutCount() );
+
+					stats.clear();
+
+					assertFalse( Hibernate.isInitialized( anEntity1.values ) );
+					Hibernate.initialize( anEntity1.values );
+
+					// anEntity1.values gets cached when it gets loadead
+					cacheStatistics = stats.getSecondLevelCacheStatistics( REGION_NAME );
+					assertEquals( 1, cacheStatistics.getMissCount() );
+					assertEquals( 0, cacheStatistics.getHitCount() );
+					assertEquals( 1, cacheStatistics.getPutCount() );
+
+					stats.clear();
+
+					AnotherEntity anotherEntity1 = s.get( AnotherEntity.class, anotherEntity.id );
+
+					// anotherEntity1 was cached when it was persisted
+					cacheStatistics = stats.getSecondLevelCacheStatistics( REGION_NAME );
+					assertEquals( 0, cacheStatistics.getMissCount() );
+					assertEquals( 1, cacheStatistics.getHitCount() );
+					assertEquals( 0, cacheStatistics.getPutCount() );
+
+					stats.clear();
+
+					assertFalse( Hibernate.isInitialized( anotherEntity1.values ) );
+					Hibernate.initialize( anotherEntity1.values );
+
+					// anotherEntity1.values gets cached when it gets loadead
+					cacheStatistics = stats.getSecondLevelCacheStatistics( REGION_NAME );
+					assertEquals( 1, cacheStatistics.getMissCount() );
+					assertEquals( 0, cacheStatistics.getHitCount() );
+					assertEquals( 1, cacheStatistics.getPutCount() );
+
+				}
+		);
+
+		// The entities and their collections should all be cached now.
+
+		withTxSession(
+				s -> {
+
+					stats.clear();
+
+					AnEntity anEntity1 = s.get( AnEntity.class, anEntity.id );
+
+					SecondLevelCacheStatistics cacheStatistics = stats.getSecondLevelCacheStatistics( REGION_NAME );
+
+					assertEquals( 0, cacheStatistics.getMissCount() );
+					assertEquals( 1, cacheStatistics.getHitCount() );
+					assertEquals( 0, cacheStatistics.getPutCount() );
+
+					stats.clear();
+
+					assertFalse( Hibernate.isInitialized( anEntity1.values ) );
+					Hibernate.initialize( anEntity1.values );
+
+					cacheStatistics = stats.getSecondLevelCacheStatistics( REGION_NAME );
+					assertEquals( 0, cacheStatistics.getMissCount() );
+					assertEquals( 1, cacheStatistics.getHitCount() );
+					assertEquals( 0, cacheStatistics.getPutCount() );
+
+					assertEquals( anEntity.values, anEntity1.values );
+
+					stats.clear();
+
+					AnotherEntity anotherEntity1 = s.get( AnotherEntity.class, anotherEntity.id );
+
+					cacheStatistics = stats.getSecondLevelCacheStatistics( REGION_NAME );
+					assertEquals( 0, cacheStatistics.getMissCount() );
+					assertEquals( 1, cacheStatistics.getHitCount() );
+					assertEquals( 0, cacheStatistics.getPutCount() );
+
+					stats.clear();
+
+					assertFalse( Hibernate.isInitialized( anotherEntity1.values ) );
+					Hibernate.initialize( anotherEntity1.values );
+
+					cacheStatistics = stats.getSecondLevelCacheStatistics( REGION_NAME );
+					assertEquals( 0, cacheStatistics.getMissCount() );
+					assertEquals( 1, cacheStatistics.getHitCount() );
+					assertEquals( 0, cacheStatistics.getPutCount() );
+
+					assertEquals( anotherEntity.values, anotherEntity1.values );
+				}
+		);
+	}
+
+	@Entity(name = "AnEntity")
+	@Cache( usage = CacheConcurrencyStrategy.TRANSACTIONAL, region = REGION_NAME)
+	public static class AnEntity {
+		@Id
+		private int id;
+
+		@ElementCollection
+		@Cache( usage = CacheConcurrencyStrategy.TRANSACTIONAL, region = REGION_NAME)
+		private Set<String> values = new HashSet<>();
+	}
+
+	@Entity(name = "AnotherEntity")
+	@Cache( usage = CacheConcurrencyStrategy.TRANSACTIONAL, region = REGION_NAME)
+	public static class AnotherEntity {
+		@Id
+		private int id;
+
+		@ElementCollection
+		@Cache( usage = CacheConcurrencyStrategy.TRANSACTIONAL, region = REGION_NAME)
+		private Set<Integer> values = new HashSet<>();
+	}
+
+}

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/SpatialDialect.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/SpatialDialect.java
@@ -70,7 +70,6 @@ public interface SpatialDialect extends Serializable {
 	 */
 	public String getHavingSridSQL(String columnName);
 
-
 	/**
 	 * Returns the SQL fragment when parsing a <code>IsEmptyExpression</code> or
 	 * <code>IsNotEmpty</code> expression.
@@ -81,6 +80,15 @@ public interface SpatialDialect extends Serializable {
 	 * @return The SQL fragment for the isempty function
 	 */
 	public String getIsEmptySQL(String columnName, boolean isEmpty);
+
+	/**
+	 * Returns the SQL fragment when parsing an <code>GeometryTypeExpression</code>.
+	 *
+	 * @param columnName the geometry column
+	 *
+	 * @return The SQL fragment for the geometrytype function
+	 */
+	public String getGeometryTypeSQL(String columnName);
 
 	/**
 	 * Returns true if this <code>SpatialDialect</code> supports a specific filtering function.

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/criterion/GeometryTypeFilterExpression.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/criterion/GeometryTypeFilterExpression.java
@@ -1,0 +1,45 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.spatial.criterion;
+
+import org.hibernate.Criteria;
+import org.hibernate.HibernateException;
+import org.hibernate.criterion.CriteriaQuery;
+import org.hibernate.criterion.Criterion;
+import org.hibernate.engine.spi.TypedValue;
+import org.hibernate.spatial.SpatialDialect;
+import org.hibernate.spatial.SpatialFunction;
+
+public class GeometryTypeFilterExpression implements Criterion {
+
+	private final String propertyName;
+	private final String geometryType;
+
+	public GeometryTypeFilterExpression(String propertyName, String geometryType) {
+		this.propertyName = propertyName;
+		this.geometryType = geometryType;
+	}
+
+	@Override
+	public String toSqlString(Criteria criteria, CriteriaQuery criteriaQuery) throws HibernateException {
+		final SpatialDialect spatialDialect = getSpatialDialect( criteriaQuery );
+		return spatialDialect.getGeometryTypeSQL( getColumn( criteria, criteriaQuery ));
+	}
+
+	private String getColumn(Criteria criteria, CriteriaQuery criteriaQuery) {
+		return ExpressionUtil.findColumn(propertyName, criteria, criteriaQuery);
+	}
+
+	private SpatialDialect getSpatialDialect(CriteriaQuery criteriaQuery){
+		return ExpressionUtil.getSpatialDialect(criteriaQuery, SpatialFunction.geometrytype);
+	}
+
+	@Override
+	public TypedValue[] getTypedValues(Criteria criteria, CriteriaQuery criteriaQuery) throws HibernateException {
+		return new TypedValue[] { criteriaQuery.getTypedValue( criteria, propertyName, geometryType ) };
+	}
+}

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/criterion/SpatialRestrictions.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/criterion/SpatialRestrictions.java
@@ -8,7 +8,6 @@ package org.hibernate.spatial.criterion;
 
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Geometry;
-
 import org.hibernate.criterion.Criterion;
 import org.hibernate.spatial.SpatialRelation;
 
@@ -246,6 +245,20 @@ public class SpatialRestrictions {
 	 */
 	public static Criterion isNotEmpty(String propertyName) {
 		return new IsEmptyExpression( propertyName, false );
+	}
+
+	/**
+	 * Apply an "geometry type filter" constraint to the named property
+	 *
+	 * @param propertyName The name of the property
+	 * @param filterValue The filter value
+	 *
+	 * @return A GeometryTypeFilterExpression
+	 *
+	 * @see GeometryTypeFilterExpression
+	 */
+	public static Criterion geometryType(String propertyName, String filterValue) {
+		return new GeometryTypeFilterExpression(propertyName, filterValue);
 	}
 
 	/**

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/h2geodb/GeoDBDialect.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/h2geodb/GeoDBDialect.java
@@ -11,8 +11,6 @@ import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.function.StandardSQLFunction;
 import org.hibernate.service.ServiceRegistry;
-
-
 import org.hibernate.spatial.GeolatteGeometryType;
 import org.hibernate.spatial.JTSGeometryType;
 import org.hibernate.spatial.SpatialDialect;
@@ -116,6 +114,11 @@ public class GeoDBDialect extends H2Dialect implements SpatialDialect {
 	}
 
 	@Override
+	public String getGeometryTypeSQL(String columnName) {
+		return "( GeometryType(" + columnName + ") = ?)";
+	}
+
+	@Override
 	public String getSpatialFilterExpression(String columnName) {
 		return "(" + columnName + " && ? ) ";
 	}
@@ -151,7 +154,7 @@ public class GeoDBDialect extends H2Dialect implements SpatialDialect {
 
 	@Override
 	public boolean supports(SpatialFunction function) {
-		return function != SpatialFunction.difference && (getFunctions().get( function.toString() ) != null);
+		return function != SpatialFunction.difference && (getFunctions().get(function.toString()) != null);
 	}
 
 }

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/hana/HANASpatialDialect.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/hana/HANASpatialDialect.java
@@ -162,6 +162,11 @@ public class HANASpatialDialect extends HANAColumnStoreDialect implements Spatia
 	}
 
 	@Override
+	public String getGeometryTypeSQL(String columnName) {
+		return columnName + ".ST_GeometryType() = ?";
+	}
+
+	@Override
 	public boolean supportsFiltering() {
 		return true;
 	}

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/mysql/MySQL56SpatialDialect.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/mysql/MySQL56SpatialDialect.java
@@ -12,7 +12,6 @@ package org.hibernate.spatial.dialect.mysql;
  */
 
 import java.util.Map;
-
 import org.hibernate.HibernateException;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.MySQL55Dialect;
@@ -138,6 +137,11 @@ public class MySQL56SpatialDialect extends MySQL55Dialect implements SpatialDial
 	@Override
 	public String getIsEmptySQL(String columnName, boolean isEmpty) {
 		return dialectDelegate.getIsEmptySQL( columnName, isEmpty );
+	}
+
+	@Override
+	public String getGeometryTypeSQL(String columnName) {
+		return dialectDelegate.getGeometryTypeSQL( columnName );
 	}
 
 	@Override

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/mysql/MySQL5SpatialDialect.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/mysql/MySQL5SpatialDialect.java
@@ -7,7 +7,6 @@
 package org.hibernate.spatial.dialect.mysql;
 
 import java.util.Map;
-
 import org.hibernate.HibernateException;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.InnoDBStorageEngine;
@@ -85,6 +84,11 @@ public class MySQL5SpatialDialect extends MySQL5Dialect implements SpatialDialec
 	@Override
 	public String getIsEmptySQL(String columnName, boolean isEmpty) {
 		return dialectDelegate.getIsEmptySQL( columnName, isEmpty );
+	}
+
+	@Override
+	public String getGeometryTypeSQL(String columnName) {
+		return dialectDelegate.getGeometryTypeSQL( columnName );
 	}
 
 	@Override

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/mysql/MySQLSpatialDialect.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/mysql/MySQLSpatialDialect.java
@@ -7,7 +7,6 @@
 package org.hibernate.spatial.dialect.mysql;
 
 import java.util.Map;
-
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.dialect.function.SQLFunction;
@@ -100,6 +99,11 @@ public class MySQLSpatialDialect extends MySQLDialect implements SpatialDialect 
 	public String getIsEmptySQL(String columnName, boolean isEmpty) {
 		final String emptyExpr = " IsEmpty(" + columnName + ") ";
 		return isEmpty ? emptyExpr : "( NOT " + emptyExpr + ")";
+	}
+
+	@Override
+	public String getGeometryTypeSQL(String columnName) {
+		return "( ST_GeometryType(" + columnName + ") = ?)";
 	}
 
 	@Override

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/oracle/OracleSDOSupport.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/oracle/OracleSDOSupport.java
@@ -7,12 +7,8 @@
 package org.hibernate.spatial.dialect.oracle;
 
 import java.io.Serializable;
-
 import org.geolatte.geom.codec.db.oracle.ConnectionFinder;
 import org.geolatte.geom.codec.db.oracle.OracleJDBCTypeFactory;
-
-import org.jboss.logging.Logger;
-
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.boot.registry.selector.spi.StrategySelector;
 import org.hibernate.engine.config.spi.ConfigurationService;
@@ -25,6 +21,7 @@ import org.hibernate.spatial.SpatialDialect;
 import org.hibernate.spatial.SpatialFunction;
 import org.hibernate.spatial.SpatialRelation;
 import org.hibernate.spatial.dialect.SpatialFunctionsRegistry;
+import org.jboss.logging.Logger;
 
 /**
  * SDO Geometry support for Oracle dialects
@@ -301,6 +298,20 @@ class OracleSDOSupport implements SpatialDialect, Serializable {
 	public String getIsEmptySQL(String columnName, boolean isEmpty) {
 		return String.format( "( MDSYS.ST_GEOMETRY(%s).ST_ISEMPTY() = %d )", columnName, isEmpty ? 1 : 0 );
 	}
+
+	/**
+	 * Returns the SQL fragment when parsing a
+	 * <code>GeometryTypeFilterExpression</code> expression
+	 *
+	 * @param columnName The geometry column
+	 *
+	 * @return The SQL fragment for the geometrytype function
+	 */
+	@Override
+	public String getGeometryTypeSQL(String columnName) {
+		return String.format( " (MDSYS.ST_GEOMETRY(%s).GET_GTYPE() = ?)", columnName );
+	}
+
 
 	/**
 	 * Returns true if this <code>SpatialDialect</code> supports a specific filtering function.

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/oracle/OracleSpatial10gDialect.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/oracle/OracleSpatial10gDialect.java
@@ -10,24 +10,14 @@ package org.hibernate.spatial.dialect.oracle;
 import java.io.Serializable;
 import java.sql.Types;
 import java.util.Map;
-
-import org.geolatte.geom.codec.db.oracle.ConnectionFinder;
-import org.geolatte.geom.codec.db.oracle.OracleJDBCTypeFactory;
-
-import org.jboss.logging.Logger;
-
 import org.hibernate.boot.model.TypeContributions;
-import org.hibernate.boot.registry.selector.spi.StrategySelector;
 import org.hibernate.dialect.Oracle10gDialect;
 import org.hibernate.dialect.function.SQLFunction;
-import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.service.ServiceRegistry;
-import org.hibernate.spatial.GeolatteGeometryType;
 import org.hibernate.spatial.HSMessageLogger;
-import org.hibernate.spatial.HibernateSpatialConfigurationSettings;
-import org.hibernate.spatial.JTSGeometryType;
 import org.hibernate.spatial.SpatialDialect;
 import org.hibernate.spatial.SpatialFunction;
+import org.jboss.logging.Logger;
 
 /**
  * Spatial Dialect for Oracle10g databases.
@@ -97,6 +87,11 @@ public class OracleSpatial10gDialect extends Oracle10gDialect implements Spatial
 	@Override
 	public String getIsEmptySQL(String columnName, boolean isEmpty) {
 		return sdoSupport.getIsEmptySQL( columnName, isEmpty );
+	}
+
+	@Override
+	public String getGeometryTypeSQL(String columnName) {
+		throw new UnsupportedOperationException("Not supported yet.");
 	}
 
 	@Override

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/oracle/OracleSpatialSDO10gDialect.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/oracle/OracleSpatialSDO10gDialect.java
@@ -9,9 +9,6 @@ package org.hibernate.spatial.dialect.oracle;
 import java.io.Serializable;
 import java.sql.Types;
 import java.util.Map;
-
-import org.jboss.logging.Logger;
-
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.Oracle10gDialect;
 import org.hibernate.dialect.function.SQLFunction;
@@ -19,6 +16,7 @@ import org.hibernate.service.ServiceRegistry;
 import org.hibernate.spatial.HSMessageLogger;
 import org.hibernate.spatial.SpatialDialect;
 import org.hibernate.spatial.SpatialFunction;
+import org.jboss.logging.Logger;
 
 /**
  * A Spatial Dialect for Oracle 10g/11g that uses the "native" SDO spatial operators.
@@ -88,6 +86,11 @@ public class OracleSpatialSDO10gDialect extends Oracle10gDialect implements Spat
 	@Override
 	public String getIsEmptySQL(String columnName, boolean isEmpty) {
 		return sdoSupport.getIsEmptySQL( columnName, isEmpty );
+	}
+
+	@Override
+	public String getGeometryTypeSQL(String columnName) {
+		return sdoSupport.getGeometryTypeSQL( columnName );
 	}
 
 	@Override

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PostgisPG82Dialect.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PostgisPG82Dialect.java
@@ -7,7 +7,6 @@
 package org.hibernate.spatial.dialect.postgis;
 
 import java.util.Map;
-
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.PostgreSQL82Dialect;
 import org.hibernate.dialect.function.SQLFunction;
@@ -67,6 +66,11 @@ public class PostgisPG82Dialect extends PostgreSQL82Dialect implements SpatialDi
 	@Override
 	public String getIsEmptySQL(String columnName, boolean isEmpty) {
 		return support.getIsEmptySQL( columnName, isEmpty );
+	}
+
+	@Override
+	public String getGeometryTypeSQL(String columnName) {
+		return support.getGeometryTypeSQL( columnName );
 	}
 
 	@Override

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PostgisPG91Dialect.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PostgisPG91Dialect.java
@@ -7,7 +7,6 @@
 package org.hibernate.spatial.dialect.postgis;
 
 import java.util.Map;
-
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.PostgreSQL91Dialect;
 import org.hibernate.dialect.function.SQLFunction;
@@ -130,6 +129,19 @@ public class PostgisPG91Dialect extends PostgreSQL91Dialect implements SpatialDi
 	@Override
 	public String getIsEmptySQL(String columnName, boolean isEmpty) {
 		return support.getIsEmptySQL( columnName, isEmpty );
+	}
+
+	/**
+	 * Returns the SQL fragment when parsing a
+	 * <code>GeometryTypeFilterExpression</code> expression.
+	 *
+	 * @param columnName The geometry column
+	 *
+	 * @return The SQL fragment for the geometrytype function
+	 */
+	@Override
+	public String getGeometryTypeSQL(String columnName) {
+		return support.getGeometryTypeSQL( columnName );
 	}
 
 	/**

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PostgisPG92Dialect.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PostgisPG92Dialect.java
@@ -7,7 +7,6 @@
 package org.hibernate.spatial.dialect.postgis;
 
 import java.util.Map;
-
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.PostgreSQL92Dialect;
 import org.hibernate.dialect.function.SQLFunction;
@@ -130,6 +129,19 @@ public class PostgisPG92Dialect extends PostgreSQL92Dialect implements SpatialDi
 	@Override
 	public String getIsEmptySQL(String columnName, boolean isEmpty) {
 		return support.getIsEmptySQL( columnName, isEmpty );
+	}
+
+	/**
+	 * Returns the SQL fragment when parsing a
+	 * <code>GeometryTypeFilterExpression</code> expression.
+	 *
+	 * @param columnName The geometry column
+	 *
+	 * @return The SQL fragment for the geometrytype function
+	 */
+	@Override
+	public String getGeometryTypeSQL(String columnName) {
+		return support.getGeometryTypeSQL( columnName );
 	}
 
 	/**

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PostgisPG93Dialect.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PostgisPG93Dialect.java
@@ -7,7 +7,6 @@
 package org.hibernate.spatial.dialect.postgis;
 
 import java.util.Map;
-
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.PostgreSQL93Dialect;
 import org.hibernate.dialect.function.SQLFunction;
@@ -132,6 +131,19 @@ public class PostgisPG93Dialect extends PostgreSQL93Dialect implements SpatialDi
 		return support.getIsEmptySQL( columnName, isEmpty );
 	}
 
+	/**
+	 * Returns the SQL fragment when parsing a
+	 * <code>GeometryTypeFilterExpression</code> expression.
+	 *
+	 * @param columnName The geometry column
+	 *
+	 * @return The SQL fragment for the geometrytype function
+	 */
+	@Override
+	public String getGeometryTypeSQL(String columnName) {
+		return support.getGeometryTypeSQL( columnName );
+	}
+	
 	/**
 	 * Returns true if this <code>SpatialDialect</code> supports a specific filtering function.
 	 * <p> This is intended to signal DB-support for fast window queries, or MBR-overlap queries.</p>

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PostgisPG94Dialect.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PostgisPG94Dialect.java
@@ -7,7 +7,6 @@
 package org.hibernate.spatial.dialect.postgis;
 
 import java.util.Map;
-
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.PostgreSQL94Dialect;
 import org.hibernate.dialect.function.SQLFunction;
@@ -132,6 +131,19 @@ public class PostgisPG94Dialect extends PostgreSQL94Dialect implements SpatialDi
 		return support.getIsEmptySQL( columnName, isEmpty );
 	}
 
+	/**
+	 * Returns the SQL fragment when parsing a
+	 * <code>GeometryTypeFilterExpression</code> expression.
+	 *
+	 * @param columnName The geometry column
+	 *
+	 * @return The SQL fragment for the geometrytype function
+	 */
+	@Override
+	public String getGeometryTypeSQL(String columnName) {
+		return support.getGeometryTypeSQL( columnName );
+	}
+	
 	/**
 	 * Returns true if this <code>SpatialDialect</code> supports a specific filtering function.
 	 * <p> This is intended to signal DB-support for fast window queries, or MBR-overlap queries.</p>

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PostgisPG95Dialect.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PostgisPG95Dialect.java
@@ -7,7 +7,6 @@
 package org.hibernate.spatial.dialect.postgis;
 
 import java.util.Map;
-
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.PostgreSQL95Dialect;
 import org.hibernate.dialect.function.SQLFunction;
@@ -131,6 +130,19 @@ public class PostgisPG95Dialect extends PostgreSQL95Dialect implements SpatialDi
 		return support.getIsEmptySQL( columnName, isEmpty );
 	}
 
+	/**
+	 * Returns the SQL fragment when parsing a
+	 * <code>GeometryTypeFilterExpression</code> expression.
+	 *
+	 * @param columnName The geometry column
+	 *
+	 * @return The SQL fragment for the geometrytype function
+	 */
+	@Override
+	public String getGeometryTypeSQL(String columnName) {
+		return support.getGeometryTypeSQL( columnName );
+	}
+	
 	/**
 	 * Returns true if this <code>SpatialDialect</code> supports a specific filtering function.
 	 * <p> This is intended to signal DB-support for fast window queries, or MBR-overlap queries.</p>

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PostgisPG9Dialect.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PostgisPG9Dialect.java
@@ -7,7 +7,6 @@
 package org.hibernate.spatial.dialect.postgis;
 
 import java.util.Map;
-
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.PostgreSQL9Dialect;
 import org.hibernate.dialect.function.SQLFunction;
@@ -132,6 +131,19 @@ public class PostgisPG9Dialect extends PostgreSQL9Dialect implements SpatialDial
 		return support.getIsEmptySQL( columnName, isEmpty );
 	}
 
+	/**
+	 * Returns the SQL fragment when parsing a
+	 * <code>GeometryTypeFilterExpression</code> expression.
+	 *
+	 * @param columnName The geometry column
+	 *
+	 * @return The SQL fragment for the geometrytype function
+	 */
+	@Override
+	public String getGeometryTypeSQL(String columnName) {
+		return support.getGeometryTypeSQL( columnName );
+	}
+	
 	/**
 	 * Returns true if this <code>SpatialDialect</code> supports a specific filtering function.
 	 * <p> This is intended to signal DB-support for fast window queries, or MBR-overlap queries.</p>

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PostgisSupport.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/postgis/PostgisSupport.java
@@ -7,7 +7,6 @@
 package org.hibernate.spatial.dialect.postgis;
 
 import java.io.Serializable;
-
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.spatial.GeolatteGeometryType;
@@ -149,6 +148,11 @@ public class PostgisSupport implements SpatialDialect, Serializable {
 	public String getIsEmptySQL(String columnName, boolean isEmpty) {
 		final String emptyExpr = " ST_IsEmpty(" + columnName + ") ";
 		return isEmpty ? emptyExpr : "( NOT " + emptyExpr + ")";
+	}
+
+	@Override
+	public String getGeometryTypeSQL(String columnName) {
+		return "( ST_GeometryType(" + columnName + ") = ?)";
 	}
 
 	/**

--- a/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/sqlserver/SqlServer2008SpatialDialect.java
+++ b/hibernate-spatial/src/main/java/org/hibernate/spatial/dialect/sqlserver/SqlServer2008SpatialDialect.java
@@ -11,7 +11,6 @@ package org.hibernate.spatial.dialect.sqlserver;
 import org.hibernate.boot.model.TypeContributions;
 import org.hibernate.dialect.SQLServer2008Dialect;
 import org.hibernate.dialect.function.SQLFunctionTemplate;
-
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.spatial.GeolatteGeometryType;
 import org.hibernate.spatial.JTSGeometryType;
@@ -168,6 +167,11 @@ public class SqlServer2008SpatialDialect extends SQLServer2008Dialect implements
 	public String getIsEmptySQL(String columnName, boolean isEmpty) {
 		final String base = "(" + columnName + ".STIsEmpty() ";
 		return isEmpty ? base + " = 1 )" : base + " = 0 )";
+	}
+
+	@Override
+	public String getGeometryTypeSQL(String columnName) {
+		return "(" + columnName + ".STGeometryType() = ?)";
 	}
 
 	@Override


### PR DESCRIPTION
Spatial function `geometrytype` has been registered to all dialects already but `SpatialRestrictions` misses a convenient way to add a geometry type filter to the actual `Criterion`.

The interface does not restrict the user to pass typed `org.geolatte.geom.GeometryType` but a mere `java.util.String`.

did not create an official issue (as noted in CONTRIBUTORS.md) ... please review.